### PR TITLE
Redirect to /2025/

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0;https://gwc.gocon.jp/2025/" />
     <title>Go Workshop Conference</title>
   </head>
   <body>


### PR DESCRIPTION
[gocon.jp](https://github.com/GoCon/gocon.github.io/blob/f0039bcc595e5c9d0a13b8400ecd59f9770e3277/index.html)と同じように、metaタグを使って `https://gwc.gocon.jp/2025/` にリダイレクトさせます。